### PR TITLE
PSR-4 autoloader fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.1 (November 21, 2016)
+
+- PSR-4 autoloader fix
+
 ## 0.7.0 (September 13, 2016)
 
 ### PHP Fluent HTTP Client

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   },
   "autoload": {
     "psr-4": {
-      "OLX\\": ["src/", "tests/"]
+      "OLX\\FluentHttpClient\\": ["src/", "tests/"]
     }
   }
 }


### PR DESCRIPTION
This fixes problems in projects that depend on it and try to `use OLX\FluentHttpClient` - which would fail.