### PR TITLE
Update ResponseWithAssertions.php

### DIFF
--- a/src/Response/Decorator/ResponseWithAssertions.php
+++ b/src/Response/Decorator/ResponseWithAssertions.php
@@ -160,4 +160,12 @@ class ResponseWithAssertions implements ResponseInterface
         }
         return $this->response->retrieve();
     }
+    
+     /**
+     * @return Response
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
 }


### PR DESCRIPTION
The situation is the following:
```
        $request = Athena::api()->post($this->getUri());
    
        $this->addQueryParams($request);
        $this->addOptions($options, $request);
        $this->addHeaders($headers, $request);

        $data = $this->getData();
        if ($data instanceof FormUrlEncodedPayload) {
            $request->withFormParameters($data->getFormattedData());
        } else {
            $request->withBody($data, 'application/json');
        }
        $response = $request->then()->assertThat();
        $this->assertResponse($expectedStatus, $isJson, $response);

        $retryNum = 0;
        $retryTimeInc = 5;

        while ($retryNum < 5)
        {
            try {
                $response->retrieve();
                $retryNum = 5;
            } catch (\Exception $ex) {
                echo 'Failed' . $ex->getMessage();
                if ($response->getResponse()->getResponseHolder()->getStatusCode() != 504) //or in list
                {
                    throw $ex;
                }
                $retryNum ++;
                sleep($retryTimeInc);
                $retryTimeInc += $retryTimeInc;
            }
        }
        
        return $this->parseResponse($isJson, $response);
```

If success this is ok, if not, I cannot reach the status code to retry the request in the catch part.